### PR TITLE
Command Typo

### DIFF
--- a/source/teleop.rst
+++ b/source/teleop.rst
@@ -161,4 +161,4 @@ Finally, restart the drivers so that our changes take effect:
 
 ::
 
-  >$ sudo service robot stop && sudo service robot stop
+  >$ sudo service robot restart


### PR DESCRIPTION
to restart the robot service, you need to start again after you stop,
or just `sudo service robot restart`