### PR TITLE
small revision to command typo fix

### DIFF
--- a/source/teleop.rst
+++ b/source/teleop.rst
@@ -161,4 +161,4 @@ Finally, restart the drivers so that our changes take effect:
 
 ::
 
-  >$ sudo service robot restart
+  >$ sudo service robot stop && sudo service robot start


### PR DESCRIPTION
it has been brought to my attention that we are still occasionally
having issues with service restart, in that the primesense driver
sometimes does not stop before being started, leading to a failed
head camera nodelet